### PR TITLE
hash-table values and keys should be returned in order like maphash.

### DIFF
--- a/alexandria-1/tests.lisp
+++ b/alexandria-1/tests.lisp
@@ -1630,12 +1630,9 @@
       (multiple-value-bind (res err)
           (ignore-errors
             (eval
-             '(let ((syms
-                     (with-unique-names ((foo "_foo_") (bar -bar-) (quux 42))
+             '(with-unique-names ((foo "_foo_") (bar -bar-) (quux 42))
                        (list foo bar quux))))
-               (list (find-if #'symbol-package syms)
-                (equal '("_foo_0" "-BAR-1" "q2")
-                 (mapcar #'symbol-name syms))))))
+        (declare (ignore res))
         (errorp err)))
   t)
 

--- a/alexandria-1/tests.lisp
+++ b/alexandria-1/tests.lisp
@@ -1,14 +1,10 @@
 (in-package :cl-user)
 
 (defpackage :alexandria/tests
-  (:use :cl :alexandria #+sbcl :sb-rt #-sbcl :rtest)
-  (:import-from #+sbcl :sb-rt #-sbcl :rtest
-                #:*compile-tests* #:*expected-failures*))
+  (:use :cl :alexandria-2 :cl-user))
 
 (in-package :alexandria/tests)
 
-(defun run-tests (&key ((:compiled *compile-tests*)))
-  (do-tests))
 
 (defun hash-table-test-name (name)
   ;; Workaround for Clisp calling EQL in a hash-table FASTHASH-EQL.

--- a/alexandria-2/tests.lisp
+++ b/alexandria-2/tests.lisp
@@ -1,9 +1,7 @@
 (in-package :cl-user)
 
 (defpackage :alexandria-2/tests
-  (:use :cl :alexandria-2 #+sbcl :sb-rt #-sbcl :rtest)
-  (:import-from #+sbcl :sb-rt #-sbcl :rtest
-                #:*compile-tests* #:*expected-failures*))
+  (:use :cl :alexandria-2 :cl-user))
 
 (in-package :alexandria-2/tests)
 

--- a/alexandria.asd
+++ b/alexandria.asd
@@ -73,15 +73,16 @@ the following constraints:
   :licence "Public Domain / 0-clause MIT"
   :description "Tests for Alexandria, which is a collection of portable public domain utilities."
   :author "Nikodemus Siivola <nikodemus@sb-studio.net>, and others."
-  :depends-on (:alexandria #+sbcl :sb-rt #-sbcl :rt)
-  :components ((:file "alexandria-1/tests")
+  :depends-on (:alexandria)
+  :serial t
+  :components ((:file "simple-tester")
+               (:file "alexandria-1/tests")
                (:file "alexandria-2/tests"))
   :perform (test-op (o c)
-                    (let ((unexpected-failure-p nil))
-                      (flet ((run-tests (&rest args)
-                               (unless (apply (intern (string '#:run-tests) '#:alexandria/tests) args)
-                                 (setf unexpected-failure-p t))))
-                        (run-tests :compiled nil)
-                        (run-tests :compiled t))
-                      (when unexpected-failure-p
+                    (let ((run (intern (string 'DO-TESTS) "CL-USER"))
+                          (unexpected-failure-p nil))
+                      ;; don't short-circuit!
+                      (when (concatenate 'list
+                                         (funcall run :compiled nil)
+                                         (funcall run :compiled t))
                         (error "Unexpected test failure")))))

--- a/simple-tester.lisp
+++ b/simple-tester.lisp
@@ -1,0 +1,66 @@
+(in-package :cl-user)
+
+
+(defparameter *tests* ())
+(defparameter *expected-failures* ())
+
+(defun do-tests (&key compiled)
+  (let ((fails ()))
+    (format t "~&~%Running ~d test~:p, ~a~%"
+            (length *tests*)
+            (if compiled
+                "compiled"
+                "evaluated"))
+    (dolist (tst *tests*)
+      (destructuring-bind (name fn form expected) tst
+        (destructuring-bind (err . vals)
+            (if compiled
+                (funcall fn)
+                (eval form))
+          (cond
+            ;; No errors allowed
+            (err
+             (push name fails)
+             (format t "ERROR ~a: ~a~%" name err))
+            ;; XFAIL
+            ((find name *expected-failures*)
+             (cond
+               ((equalp vals expected)
+                (push name fails)
+                (format t "XOK   ~a~%" name))
+               (t
+                (format t "XFAIL ~a:~%  got ~s,~%  expected ~s~%"
+                        name vals expected))))
+            ;; expected OK
+            (t
+             (cond
+               ((equalp vals expected)
+                (format t "OKAY  ~a~%" name))
+               (t
+                (push name fails)
+                (format t "NACK  ~a:~%  got ~s,~%  expected ~s~%"
+                        name vals expected))))))))
+    (format t "~%~d mismatches: ~s.~%~%" 
+            (length fails)
+            fails)
+    fails))
+
+(defmacro deftest (name form &rest values)
+  (let ((form `(block ,name
+                 (handler-case ,form
+                   (t (e)
+                     (list e))
+                   (:no-error (&rest vals)
+                     (list* nil vals))))))
+    `(progn
+       (setf *tests*
+             (cons (list ',name
+                         (lambda () ,form)
+                         ',form
+                         ',values)
+                   (remove ',name *tests*
+                           :key #'first)))
+       ',name)))
+
+(export '(deftest do-tests
+          *tests* *expected-failures*))


### PR DESCRIPTION
hash-table values and keys should be returned in order like maphash.